### PR TITLE
fix to #200

### DIFF
--- a/src/components/AddressesPage/AddressDetailPage/AddressTabs/index.js
+++ b/src/components/AddressesPage/AddressDetailPage/AddressTabs/index.js
@@ -315,6 +315,7 @@ function AddressTabs(props) {
                 txType={TX_TYPE.ADDRESS_BONDERS}
                 address={address}
                 bondMap={bondMap}
+                onClickTab={handleClickTab}
               />
             );
           default:

--- a/src/components/CommonComponent/AddressCell.js
+++ b/src/components/CommonComponent/AddressCell.js
@@ -87,7 +87,7 @@ function getInnerElements(props, booleans) {
 	else {
 		elements.push(
 			<span key="span" className={props.spanNoEllipsis ? '' : 'ellipsis'}>
-				{_isOtherAddress ? <AddressLink to={props.targetAddr} /> : props.address}
+				{_isOtherAddress ? <AddressLink to={props.targetAddr} onClickTab={props.onClickTab} /> : props.address}
 			</span>			
 		)
 	}

--- a/src/components/CommonComponent/Link/AddressLink.js
+++ b/src/components/CommonComponent/Link/AddressLink.js
@@ -4,7 +4,7 @@ import {
   isContractAddress
 } from '../../../utils/utils'
 
-const AddressLink = ({to, label, onClick}) => {
+const AddressLink = ({to, label, onClick, onClickTab}) => {
   return (
     <LinkCell
       pageType={isContractAddress(to) ? 'contract' : 'address'}
@@ -12,6 +12,7 @@ const AddressLink = ({to, label, onClick}) => {
       to={to}
       label={label}
       onClick={onClick}
+      onClickTab={onClickTab}
     />
   )
 }

--- a/src/components/CommonComponent/Link/LinkCell.js
+++ b/src/components/CommonComponent/Link/LinkCell.js
@@ -1,12 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const LinkCell = ({ pageType, to, label, aClassName, onClick }) => {
+const LinkCell = ({ pageType, to, label, aClassName, onClick, onClickTab }) => {
+    function handleOnClick() {
+        // This block changes the current tab to the first one (Transaction)
+        // tab once the address link is clicked
+        if (typeof onClickTab === 'function') {
+            onClickTab(0)
+        }
+        if (typeof onClick === 'function') { 
+            onClick()
+        }
+    }
     return (
         <Link
             className={aClassName}
             to={`/${pageType}/${to}`}
-            onClick={() => { if (typeof onClick === 'function') { onClick() } }}            
+            onClick={handleOnClick}            
             title={to}
         >
             {label || to}

--- a/src/components/CommonComponent/TxBottom/TxBottomComponent.js
+++ b/src/components/CommonComponent/TxBottom/TxBottomComponent.js
@@ -6,7 +6,16 @@ import { getBondList } from "../../../redux/store/iiss";
 
 class TxBottomComponent extends Component {
   render() {
-    const { txData, txType, goAllTx, address, tableClassName, noBoxText, tokenTotal } = this.props;
+    const { 
+      txData,
+      txType,
+      goAllTx,
+      address,
+      tableClassName,
+      noBoxText,
+      tokenTotal,
+      onClickTab
+    } = this.props;
     const { data, listSize, totalSize, loading } = txData;
 
     let totalCount = txData.headers ? txData.headers["x-total-count"] : 0;
@@ -44,7 +53,7 @@ class TxBottomComponent extends Component {
                 <tbody>
                   {tableBodyData.map((item, index) => (
                     <TxTableBody
-                      key={index}
+                      key={`${index}-${address}`}
                       bondMap={this.props.bondMap}
                       totalSupply={tokenTotal}
                       rank={index + 1}
@@ -52,6 +61,7 @@ class TxBottomComponent extends Component {
                       txType={txType}
                       address={address}
                       tokenTotal={tokenTotal}
+                      onClickTab={onClickTab}
                     />
                   ))}
                 </tbody>

--- a/src/components/CommonComponent/TxBottom/index.js
+++ b/src/components/CommonComponent/TxBottom/index.js
@@ -11,7 +11,8 @@ class TxBottom extends Component {
       goAllTx,
       txType,
       address,
-      tokenTotal
+      tokenTotal,
+      onClickTab
     } = this.props
 
 
@@ -35,6 +36,7 @@ class TxBottom extends Component {
         tokenTotal={tokenTotal}
         total={this.props.total}
         bondMap={this.props.bondMap?this.props.bondMap:""}
+        onClickTab={onClickTab}
       />
     )
   }

--- a/src/components/CommonPage/TxPage/TxTableBody.js
+++ b/src/components/CommonPage/TxPage/TxTableBody.js
@@ -432,11 +432,19 @@ class TxTableBody extends Component {
               </td>
             </tr>
           );
-        case TX_TYPE.ADDRESS_BONDERS:
+        case TX_TYPE.ADDRESS_BONDERS: // TODO: HERE!
           console.log(this.props.bondMap[data] > 0, "bonder bonder data");
+          console.log('this.props');
+          console.log(this.props)
           return (
             <tr>
-              <AddressCell targetAddr={data} txType={data.txType} spanNoEllipsis />
+              <AddressCell 
+                targetAddr={data} 
+                txType={data.txType} 
+                spanNoEllipsis 
+                onClickTab={this.props.onClickTab}
+              />
+              {/* <TxAddressCell isError={isError} address={data} /> */}
               <td>
                 <span>{numberWithCommas(this.props.bondMap[data]) || 0}</span>
                 <em>ICX</em>


### PR DESCRIPTION
fix: This commits fixes #200. The solution implemented to fix this issue is that now when someone clicks on an address in the bonders tab the state of the current active tab gets reset to the first tab (Transactions)