### PR TITLE
chore: linked address opens in new tab

### DIFF
--- a/src/components/CommonPage/TxPage/TxTableBody.js
+++ b/src/components/CommonPage/TxPage/TxTableBody.js
@@ -169,7 +169,7 @@ class TxTableBody extends Component {
               <td
                 className="on"
                 onClick={() => {
-                  window.open("/address/" + data.address);
+                  window.open("/address/" + data.address, "_self");
                 }}
               >
                 {/* <span className={"prep-tag" + addUnregisteredStyle(data.status, data.grade)}>{badgeTitle}</span> */}
@@ -199,7 +199,7 @@ class TxTableBody extends Component {
               <td
                 className="on"
                 onClick={() => {
-                  window.open("/address/" + data.address);
+                  window.open("/address/" + data.address,  "_self");
                 }}
               >
                 {data.address}


### PR DESCRIPTION
chore: linked address opens in new tab for delegation and bonded address #275 and #208