### PR TITLE
fix: "read contract" tab in tokens not working #284 and fix: In /token/<> there is no transactions tab #205

### DIFF
--- a/src/components/TokensPage/TokenDetailPage/TokenTabs/index.js
+++ b/src/components/TokensPage/TokenDetailPage/TokenTabs/index.js
@@ -11,12 +11,12 @@ import {
     TX_TYPE,
     TOKEN_TABS,
 } from '../../../../utils/const'
-import {getTokenDecimals, getTokenTotalSupply} from '../../../../redux/store/iiss'
+import { getTokenDecimals, getTokenTotalSupply } from '../../../../redux/store/iiss'
 // import {tokenHoldersList, tokenTransfersList} from "../../../../redux/api/restV3";
 
 class TokenTabs extends Component {
 
-    async componentDidMount(){
+    async componentDidMount() {
         // this.transferCount = await tokenTransfersList({contractAddr: this.props.match.params.tokenId})
         // this.holdersCount = await tokenHoldersList({contractAddr: this.props.match.params.tokenId})
         // this.transferCount = this.transferCount.headers["x-total-count"]
@@ -61,7 +61,7 @@ class TokenTabs extends Component {
                             return (
                                 <TokenContractRead
                                     contract={{ data: { address } }}
-                                    contractInfo={contractInfo}
+                                    contractReadWriteInfo={contractInfo}
                                     icxCall={this.props.icxCall}
                                 />
                             )

--- a/src/containers/TokensPage/TokenDetailPageContainer.js
+++ b/src/containers/TokensPage/TokenDetailPageContainer.js
@@ -15,8 +15,8 @@ import { getTokenTotalSupply } from '../../redux/store/iiss';
 function mapStateToProps(state) {
   return {
     url: state.router.location,
-    ...state.tokens,
-    contractInfo: state.contracts.contractInfo
+    contractInfo: state.contracts.contractReadInfo,
+    ...state.tokens
   };
 }
 

--- a/src/utils/const.js
+++ b/src/utils/const.js
@@ -90,7 +90,7 @@ export const CONTRACT_TABS = [
   "Events",
 ];
 export const BLOCK_TABS = ["Transactions", "Internal Transactions"];
-export const TOKEN_TABS = ["Token Transfers", "Token Holders", "Read Contract"];
+export const TOKEN_TABS = ["Transactions", "Token Transfers", "Token Holders", "Read Contract"];
 export const TRANSACTION_TABS = ["Internal Transactions", "Events"];
 export const PROPOSAL_TABS = ["Total Voters", "Total Token Votes"];
 


### PR DESCRIPTION
"Read Contract" tab is accessible now.